### PR TITLE
[TASK] Make ExtensionConfig more tolerant to missing config

### DIFF
--- a/Classes/ExtensionConfig.php
+++ b/Classes/ExtensionConfig.php
@@ -40,10 +40,10 @@ class ExtensionConfig
 
     private function setDerivedConfigOptions(): void
     {
-        $parsedUrl = parse_url((string)$this->config['serverUrl']);
+        $parsedUrl = parse_url((string)($this->config['serverUrl'] ?? ''));
         $this->config['serverHostName'] = $parsedUrl['host'] ?? '';
-        $this->config['allowedOrigin'] = ($parsedUrl['scheme'] ?? 'https') . '://' . $this->config['serverHostName'];
-        $this->config['transferSession'] = $this->needsSessionTransfer($this->config['serverHostName']);
+        $this->config['allowedOrigin'] = ($parsedUrl['scheme'] ?? 'https') . '://' . $this->config['serverHostName'] ?? '';
+        $this->config['transferSession'] = $this->needsSessionTransfer($this->config['serverHostName'] ?? '');
     }
 
     private function needsSessionTransfer(string $easyDbHostName): bool


### PR DESCRIPTION
In case of a bug of TYPO3 where extension:setup does not populate the EXTCONF array with initial (empty) extension config, the ExtensionConfig service tries to access array keys that do not exist. (See https://forge.typo3.org/issues/105267)

While this is foremost a bug in TYPO3 extension:setup handling, this workaround allows consumers of the
extension to still access their backend. Without this patch, the backend will be inaccessible due to a
PHP "undefined array keys access" message.